### PR TITLE
Issue 3 fixed: convert into int had wrong sign.

### DIFF
--- a/src/promote.jl
+++ b/src/promote.jl
@@ -17,7 +17,7 @@ promote_rule(x::Type{Rational{T}},y::Type{AlgebraicNumber{S,F}}) where {T<:Integ
 function convert(::Type{Int64},an::AlgebraicNumber)
 	c = an.coeff
 	if length(c)==2 && abs(c[2])==1
-		return convert(Int64, c[1]*c[2])
+		return convert(Int64, -c[1]*c[2])
 	else
 		throw(InexactError())
 	end


### PR DESCRIPTION
Issue https://github.com/anj1/AlgebraicNumbers.jl/issues/3
Changed       src/promote.jl

Only algberaic numbers with length(coeff) == 2 and c[2] = +- 1
can be converted exactly into an integer.
For them, the ploynomial is

c[2]*x + c[1] = 0

e.g. 2 is represented as : [-2, 1]
(as far as I see, [2, -1] doesn't occur, but tmy change can handle it.)
So we need to take -c[1]*c[2], i.e. I added the minus sign.