### PR TITLE
Make from_newton() type stable

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -54,7 +54,7 @@ to_array(p) = Rational{BigInt}[Rational(coeff(p,i)) for i=0:Nemo.degree(p)]
 function from_newton(tr::Vector{T}) where {T<:Number}
 	# special case
 	if tr==[1]
-		return [0,1]
+		return T[0,1]
 	end
 	n = length(tr)
 	c = Array{T}(UndefInitializer(),n)


### PR DESCRIPTION
this fixes a bug causing addition of `AlgebraicNumber`s to not be type stable.
E.g.
```
julia> a = AlgebraicNumber(0)
≈0.0 + 0.0im

julia> typeof(a)
AlgebraicNumber{BigInt,BigFloat}

julia> typeof(a+0)
AlgebraicNumber{Int64,BigFloat}

julia> typeof(a-0)
AlgebraicNumber{Int64,BigFloat}
```