### PR TITLE
Anj1 exactdisplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,7 @@ sqrt(AlgebraicNumber(x))^2 == x
 
 Here, `AlgebraicNumber` is just a constructor that takes a number (either an integer or a rational number) and produces an algebraic number.
 
-Note that if you display an algebraic number, you might get something like:
-```julia
-julia> AlgebraicNumber(1)
-≈1.0 + 0.0im
-```
-
-That is, something that looks like an approximate complex number, not an exact number. This is *only* the library's way of *displaying* algebraic numbers, and it's simply because in general it is impossible to represent an algebraic number exactly in decimal notation no matter how many digits you display! Internally, algebraic numbers are represented exactly, but they are not represented using decimal or floating-point representation (more on internal representation below).
-
-Indeed, you can do arithmetic on algebraic numbers and all results will be represented exactly:
+You can do arithmetic on algebraic numbers and all results will be represented exactly:
 
 ```julia
 sqrt2 = sqrt(AlgebraicNumber(2))
@@ -57,6 +49,22 @@ assert((y^2 - 1)^2 == 6)
 ```
 
 Even *more* generally, arbitrary root-taking operations are possible. That is, you can represent the root of any polynomial (with integer, rational, or algebraic coefficients) as an algebraic number, even if that root doesn't have a representation in terms of a sequence of +, -, /, *, and root-taking operations.
+
+#### Displaying algebraic numbers
+
+Note that sometimes when displaying an algebraic number, you might get a '≈' symbol, like:
+```julia
+julia> sqrt(AlgebraicNumber(2))
+≈1.4142135623730951 + 0.0im
+```
+
+That is, something that looks like an approximate complex number, not an exact number. This is *only* the library's way of *displaying* algebraic numbers, and it's simply because in general it is impossible to represent an algebraic number exactly in decimal notation no matter how many digits you display! Internally, algebraic numbers are represented exactly, but they are not represented using decimal or floating-point representation (more on internal representation below).
+
+When displaying algebraic numbers that *can* be represented exactly, they are shown as-is:
+```
+julia> AlgebraicNumber(2)
+2.0 + 0.0im
+```
 
 #### Internal implementation
 

--- a/src/algebraic.jl
+++ b/src/algebraic.jl
@@ -39,18 +39,29 @@ AlgebraicNumber(x::T) where {T<:Integer} =
 AlgebraicNumber(x::Rational) =
     AlgebraicNumber(BigInt[-numerator(x), denominator(x)], Complex{BigFloat}(x))
 
+AlgebraicNumber(x::Complex) =
+    AlgebraicNumber(real(x)) + AlgebraicNumber(imag(x))*root(AlgebraicNumber(-1),2)
+
+
 function poly_from_coeff(a)
 	R,x=PolynomialRing(Nemo.FlintZZ,"x")
 	sum([a[i]*x^(i-1) for i=1:length(a)])
 end
 
+function is_displayed_exactly(an)
+	io = IOBuffer()
+	show(io,convert(Complex{Float64},an.apprx))
+	displ = String(take!(io))
+	from_displ = AlgebraicNumber(Complex{Rational{BigInt}}(parse(Complex{BigFloat}, displ)))
+	from_displ==an, displ
+end
+
 import Base.show
 # TODO: only show up to precision
 function show(io::IO, an::AlgebraicNumber)
-	print(io,"≈")
-	#ndigits = max(10, round(Int,ceil(convert(Float64,log(an.prec)/log(10)))))
-	show(io,convert(Complex{Float64},an.apprx))
-	#print(io,"...")
+	display_exact, displ = is_displayed_exactly(an)
+	display_exact || print(io, "≈")
+	print(io, displ)
 end
 
 #get_coeffs(p::Nemo.fmpz_poly) = pointer_to_array(convert(Ptr{Int64}, p.coeffs), (p.length,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,8 +101,11 @@ end
 function test_show()
 	a = IOBuffer()
 	show(a, sqrt(AlgebraicNumber(-1))+1)
+	@test String(take!(a)) == "1.0 + 1.0im"
 
-	@test convert(UTF8String, takebuf_array(a)) == "≈1.0 + 1.0im"
+	a = IOBuffer()
+	show(a, sqrt(AlgebraicNumber(2)))
+	@test String(take!(a))[1] == '≈'
 end
 
 
@@ -113,7 +116,7 @@ plastic_constant_test()
 test_abs()
 test_real_imag()
 test_pow2()
-#test_show()
+test_show()
 
 # testcase of issue #5
 @test AlgebraicNumber(1)+sqrt(AlgebraicNumber(-1)) != AlgebraicNumber(2)


### PR DESCRIPTION
I added some code to fix the display of algebraic numbers. Specifically, some numbers, such as integers or simple rationals, can be displayed exactly so for these numbers the ≈ isn't printed.

Also updated the README and brought back the test for show().

@fkastner would appreciate if you could have a look.